### PR TITLE
Add tmux support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - This CHANGELOG file
-- Filetype support for grovy, haskel, lua, jsx,  sass and html
+- Filetype support for grovy, haskel, lua, jsx,  sass, html, tmux
 - Control for auto space after comment char according to language.
 - Specific field placeholders according to file type
 - Modified date field

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Supported filetypes are;
 - python
 - sass
 - sh
+- tmux
 - vim
 
 And licenses are;

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -84,6 +84,9 @@ fun s:set_props()
         let b:first_line = '#!/bin/bash'
         let b:comment_char = '#'
     " ----------------------------------
+    elseif b:filetype == 'tmux'
+        let b:comment_char = '#'
+    " ----------------------------------
     elseif b:filetype == 'vim'
         let b:comment_char = '"'
     " ----------------------------------


### PR DESCRIPTION
This commit adds tmux support simply by adding a `elseif` branch to detect the `tmux` filetype.

I guess this is only useful for editing `tmux.conf`.

Please take a look if this is good for this plugin.