### PR TITLE
Improved header date auto-update and add few languages support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - This CHANGELOG file
-- Filetype support for grovy, haskel, lua, jsx,  sass, html, tmux
+- Filetype support for grovy, haskel, lua, jsx,  sass, html, tmux, go, scala, ruby, elixir, erlang, plaintex, lisp, scheme, asm, clojure, cs, xdefaults, ocaml
 - Control for auto space after comment char according to language.
 - Specific field placeholders according to file type
 - Modified date field

--- a/README.md
+++ b/README.md
@@ -90,22 +90,35 @@ Support
 =======
 Supported filetypes are;
 
+- asm
 - c
+- clojure
 - cpp
+- cs
 - css
+- elixir
+- erlang
+- go
 - groovy
 - haskel
 - java
 - javascript
 - jsx
+- lisp
 - lua
+- ocaml
 - php
 - perl
+- plaintex
 - python
+- ruby
 - sass
+- scala
+- scheme
 - sh
 - tmux
 - vim
+- xdefaults
 
 And licenses are;
 

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -1,7 +1,7 @@
 " File: header.vim
 " Author: Clement Trosa <me@trosa.io>
 " Date: 27/06/2017 02:13:35 PM
-" Last Modified: 27/06/2017 02:34:17 PM
+" Last Modified: 27/06/2017 02:37:58 PM
 " PROPERTIES AND FUNCTIONS FOR GENERAL PURPOSES
 " ---------------------------------------------
 " Set default global values
@@ -116,7 +116,7 @@ fun s:set_props()
     elseif b:filetype == "xdefaults"
         let b:comment_char = "!!"
     " ----------------------------------
-    elseif b:filetype == "ocalm"
+    elseif b:filetype == "ocaml"
         let b:comment_begin = "(**"
         let b:comment_end = "*)"
         let b:comment_char = "*"

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -1,3 +1,7 @@
+" File: header.vim
+" Author: Clement Trosa <me@trosa.io>
+" Date: 27/06/2017 02:13:35 PM
+" Last Modified: 27/06/2017 02:22:14 PM
 " PROPERTIES AND FUNCTIONS FOR GENERAL PURPOSES
 " ---------------------------------------------
 " Set default global values
@@ -49,6 +53,7 @@ fun s:set_props()
         \ b:filetype == 'css' ||
         \ b:filetype == 'groovy' ||
         \ b:filetype == 'java' ||
+        \ b:filetype == 'scala' ||
         \ b:filetype == 'javascript' ||
         \ b:filetype == 'javascript.jsx' ||
         \ b:filetype == 'php' ||
@@ -84,11 +89,28 @@ fun s:set_props()
         let b:first_line = '#!/bin/bash'
         let b:comment_char = '#'
     " ----------------------------------
+    elseif b:filetype == "ruby" ||
+          \ b:filetype == "elixir"
+        let b:comment_char = '#'
+    " ----------------------------------
+    elseif b:filetype == "erl" ||
+          \ b:filetype == "plaintex"
+        let b:comment_char = "%%"
+    " ----------------------------------
     elseif b:filetype == 'tmux'
         let b:comment_char = '#'
     " ----------------------------------
-    elseif b:filetype == 'vim'
+    elseif b:filetype == 'vim' ||
+          \ b:filetype == "asm"
         let b:comment_char = '"'
+    " ----------------------------------
+    elseif b:filetype == "lisp" ||
+          \ b:filetype == "scheme" ||
+          \ b:filetype == "clojure"
+        let b:comment_char = ";;"
+    " ----------------------------------
+    elseif b:filetype == "cs"
+        let b:comment_char = "//"
     " ----------------------------------
     elseif b:filetype == 'html'
         let b:first_line = '<!DOCTYPE html>'

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -1,7 +1,7 @@
 " File: header.vim
 " Author: Clement Trosa <me@trosa.io>
 " Date: 27/06/2017 02:13:35 PM
-" Last Modified: 27/06/2017 02:22:14 PM
+" Last Modified: 27/06/2017 02:34:17 PM
 " PROPERTIES AND FUNCTIONS FOR GENERAL PURPOSES
 " ---------------------------------------------
 " Set default global values
@@ -57,6 +57,7 @@ fun s:set_props()
         \ b:filetype == 'javascript' ||
         \ b:filetype == 'javascript.jsx' ||
         \ b:filetype == 'php' ||
+        \ b:filetype == 'go' ||
         \ b:filetype == 'sass'
 
         let b:block_comment = 1
@@ -93,24 +94,33 @@ fun s:set_props()
           \ b:filetype == "elixir"
         let b:comment_char = '#'
     " ----------------------------------
-    elseif b:filetype == "erl" ||
+    elseif b:filetype == "erlang" ||
           \ b:filetype == "plaintex"
         let b:comment_char = "%%"
     " ----------------------------------
     elseif b:filetype == 'tmux'
         let b:comment_char = '#'
     " ----------------------------------
-    elseif b:filetype == 'vim' ||
-          \ b:filetype == "asm"
+    elseif b:filetype == 'vim'
         let b:comment_char = '"'
     " ----------------------------------
     elseif b:filetype == "lisp" ||
           \ b:filetype == "scheme" ||
+          \ b:filetype == "asm" ||
           \ b:filetype == "clojure"
-        let b:comment_char = ";;"
+        let b:comment_char = ";"
     " ----------------------------------
     elseif b:filetype == "cs"
         let b:comment_char = "//"
+    " ----------------------------------
+    elseif b:filetype == "xdefaults"
+        let b:comment_char = "!!"
+    " ----------------------------------
+    elseif b:filetype == "ocalm"
+        let b:comment_begin = "(**"
+        let b:comment_end = "*)"
+        let b:comment_char = "*"
+        let b:block_comment = 1
     " ----------------------------------
     elseif b:filetype == 'html'
         let b:first_line = '<!DOCTYPE html>'

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -104,7 +104,7 @@ fun s:set_props()
           \ b:filetype == "scheme" ||
           \ b:filetype == "asm" ||
           \ b:filetype == "clojure"
-        let b:comment_char = ";"
+        let b:comment_char = ";;"
     " ----------------------------------
     elseif b:filetype == "cs"
         let b:comment_char = "//"

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -1,7 +1,3 @@
-" File: header.vim
-" Author: Clement Trosa <me@trosa.io>
-" Date: 27/06/2017 02:13:35 PM
-" Last Modified: 27/06/2017 02:37:58 PM
 " PROPERTIES AND FUNCTIONS FOR GENERAL PURPOSES
 " ---------------------------------------------
 " Set default global values

--- a/plugin/header.vim
+++ b/plugin/header.vim
@@ -10,4 +10,5 @@ command! AddGNULicense call header#add_header(2, 'gnu', 0)
 " Set default global values
 if !exists('g:header_auto_add_header') || g:header_auto_add_header == 1
     autocmd BufNewFile * call header#add_header(0, 0, 1)
+    autocmd BufWritePre * silent! :AddHeader " Update date when saving buffer
 endif


### PR DESCRIPTION
Hello,
Added a small fix in header plugin to update date & filepath when saving buffer:
```vim
autocmd BufWritePre * silent! :AddHeader
```
Also added support for these languages:
- Scala
- Go
- Ruby
- Elixir
- Erlang
- Tex
- Lisp(s)
- Scheme(s)
- C#
- Assembly
- Xresources
- Ocaml

There is still a lot of language but these are the ones I use most.

Regards,
Clement