### PR TITLE
Add last modified author and other minor document changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ For example, when you open a file named `start.sh` and press `F4` after above se
 # File: start.sh
 # Author: Your Name <your@mail>
 # Date: 13.03.2016
-# Last Modified: 13.03.2016
+# Last Modified Date: 13.03.2016
+# Last Modified By: Your Name <your@mail>
 ```
 or for a file named `index.php`
 ```php
@@ -38,7 +39,8 @@ or for a file named `index.php`
  * File: index.php
  * @author: Your Name <your@mail>
  * Date: 13.03.2016
- * Last Modified: 13.03.2016
+ * Last Modified Date: 13.03.2016
+ * Last Modified By: Your Name <your@mail>
  */
 ```
 Commands
@@ -77,6 +79,10 @@ It disables to add creating date line. Default is 1.
 let g:header_field_modified_timestamp = 0
 ```
 It disables to add modified date line. Default is 1.
+```vim
+let g:header_field_modified_by = 0
+```
+It disables to add modified author line. Default is 1. Likewise the author name line, if you don't define your author name, this line won't be shown. If your email is defined together with your name, your email will be appended after your author name.
 ```vim
 let g:header_field_timestamp_format = '%d.%m.%Y'
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-#vim-header
+vim-header
+==========
 Easily adds brief author info and license headers
 
 Install
-=======
+-------
 Preferred installation method is [Pathogen](https://github.com/tpope/vim-pathogen)
 ```sh
 cd ~/.vim/bundle
@@ -11,7 +12,7 @@ git clone https://github.com/alpertuna/vim-header
 Or you can use your own way
 
 Usage
-=====
+-----
 This is a general usage example.
 You can add these lines into your `.vimrc`
 ```vim
@@ -22,7 +23,7 @@ map <F4> :AddHeader<CR>
 Pressing `F4` in normal mode will add a brief author information at the top of your buffer.
 
 Examples
-========
+--------
 For example, when you open a file named `start.sh` and press `F4` after above settings, plugin will add these lines at the top of your buffer
 ```sh
 #!/bin/bash
@@ -44,7 +45,7 @@ or for a file named `index.php`
  */
 ```
 Commands
-========
+--------
 Adding Brief Headers
 
 - `:AddHeader` Adds brief author information or updates if exists
@@ -57,7 +58,7 @@ Adding Lincenses
 - `:AddGNULicense` Adds GNU License with author info
 
 Settings
-========
+--------
 These settings are for your `.vimrc`
 ```vim
 let g:header_field_filename = 0
@@ -93,7 +94,7 @@ let g:header_auto_add_header = 0
 It disables to add header automatically. Default is 1.
 
 Support
-=======
+-------
 Supported filetypes are;
 
 - asm
@@ -134,5 +135,5 @@ And licenses are;
 
 If you want more filetypes or licenses, you can open issues or provide any improvements by pull requests on [alpertuna/vim-header](https://github.com/alpertuna/vim-header). Also you can correct my English on README file or at comments in source code.
 
-###Thanks to Contributors
+### Thanks to Contributors
 [Contributors List](https://github.com/alpertuna/vim-header/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ It adds your name as author. Default is ''. Empty string means to disable adding
 ```vim
 let g:header_field_author_email = 'your@mail'
 ```
-It adds your email after author name with surrounding `<``>` chars. If you don't define your author name, defined email also won't be shown. Default is ''. Empty string means to disable adding it.
+It adds your email after author name with surrounding `<` `>` chars. If you don't define your author name, defined email also won't be shown. Default is ''. Empty string means to disable adding it.
 ```vim
 let g:header_field_timestamp = 0
 ```

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -91,15 +91,13 @@ fun s:set_props()
         let b:comment_char = '#'
     " ----------------------------------
     elseif b:filetype == "ruby" ||
-          \ b:filetype == "elixir"
+          \ b:filetype == "elixir" ||
+          \ b:filetype == "tmux"
         let b:comment_char = '#'
     " ----------------------------------
     elseif b:filetype == "erlang" ||
           \ b:filetype == "plaintex"
         let b:comment_char = "%%"
-    " ----------------------------------
-    elseif b:filetype == 'tmux'
-        let b:comment_char = '#'
     " ----------------------------------
     elseif b:filetype == 'vim'
         let b:comment_char = '"'

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -16,6 +16,9 @@ endif
 if !exists('g:header_field_modified_timestamp')
     let g:header_field_modified_timestamp = 1
 endif
+if !exists('g:header_field_modified_by')
+    let g:header_field_modified_by = 1
+endif
 if !exists('g:header_field_timestamp_format')
     let g:header_field_timestamp_format = '%d.%m.%Y'
 endif
@@ -40,7 +43,8 @@ fun s:set_props()
     let b:field_file = 'File:'
     let b:field_author = 'Author:'
     let b:field_date = 'Date:'
-    let b:field_modified_date = 'Last Modified:'
+    let b:field_modified_date = 'Last Modified Date:'
+    let b:field_modified_by= 'Last Modified By:'
 
     " Setting Values for Languages
     if
@@ -202,6 +206,15 @@ fun s:add_header()
         call append(l:i, b:comment_char . b:field_modified_date . ' ' . strftime(g:header_field_timestamp_format))
         let l:i += 1
     endif
+    if g:header_field_modified_by && g:header_field_author != ''
+        if g:header_field_author_email != ''
+            let l:email = ' <' . g:header_field_author_email . '>'
+        else
+            let l:email = ''
+        endif
+        call append(l:i, b:comment_char . b:field_modified_by . ' ' . g:header_field_author . l:email)
+        let l:i += 1
+    endif
 
     " If filetype supports block comment, close comment
     if b:block_comment
@@ -220,6 +233,16 @@ fun s:update_header()
     if g:header_field_modified_timestamp
         let l:field = substitute(substitute(substitute(b:comment_char . b:field_modified_date, '\*', '\\\*', ''), '\.', '\\\.', ''), '@', '\\@', '')
         silent! execute '/' . b:comment_char . b:field_modified_date . '/s@.*$@\=''' . l:field . ' '' . strftime("' . g:header_field_timestamp_format . '")@'
+    endif
+    " Update last modified author
+    if g:header_field_modified_by && g:header_field_author != ''
+        if g:header_field_author_email != ''
+            let l:email = ' <' . g:header_field_author_email . '>'
+        else
+            let l:email = ''
+        endif
+        let l:field = substitute(substitute(substitute(b:comment_char . b:field_modified_by, '\*', '\\\*', ''), '\.', '\\\.', ''), '@', '\\@', '')
+        silent! execute '/' . b:comment_char . b:field_modified_by . '/s@.*$@\=''' . l:field . ' '' . g:header_field_author . l:email@'
     endif
     echo 'Header was updated succesfully.'
 endfun


### PR DESCRIPTION
### TL;DR

- Add last modified author feature
- Change `README.md`

### This PR includes the following changes:

- feat: add last modified author
  - The majority of this code is reused from the modified timestamp code
  - This feature is inspired by the Atom's `file-header` plugin (https://github.com/guiguan/file-header/)
  - The `Last Modified:` label has been changed to `Last Modified Date:` according to this change
- docs: update README.md for last modified author
  - Update README.md according to the new last modified author feature
  
  NB: I am not a native speaker of English; please review what I have changed.

- refactor: include tmux filetype to existing elseif block

  In a previous commit, new filetypes: ruby and elixir were added by
  @iomonad. Since the comment character for these two languages is a hash
  (#), which is the same for tmux, the conditional statement for detecting
  tmux filetype has been included to the `elseif` block for ruby and
  elixir.

- docs: change markdown headings

    At the top of README.md, there was a line goes like this: `#vim-header`;
    using the `===` Markdown syntax to make sure that this line will be
    rendered as a H1 heading.

    The similar change applies for `###Thanks to Contributors` line,
    changing it to be rendered as a H3 heading.

    This could be a matter of style preference but all other H1 headings
    have been converted to H2 headings.

- docs: fix a minor Markdown rendering mistake

    In Markdown (at least this is observed for GFM), a pair of inner
    backticks are recognised as normal strings inside a pair of outer
    backticks if it is written like this: `<``>`. Insert a space character
    like this: `<` `>` so that it will be render properly.

### Notes

There are a few minor things I was thinking regarding the last modified author feature:

  - The newly modified `Last Modified Date:` label and the newly added `Last Modified By:` label are both capitalised in every letter. I was thinking of changing these to `Last modified date:` and `Last modified by:`. I wanted to hear your preference.
  - The order of headers is currently as follows:

    ```
    # File: filename.extension
    # Author: Firstname Lastname <username@example.com>
    # Date: d.m.Y
    # Last Modified Date: d.m.Y
    # Last Modified By: Firstname Lastname <username@example.com>
    ```
    I was thinking that what's the most natural order for this but for now I located the `Last Modified By:` line at the bottom so that `Date:` and `Last Modified Date:` are easily comparable. Please change as you feel natural.
  - I was thinking of including a username (perhaps for GitHub) somewhere but did not do it in the end

---

### Finally

Please have a look if this is feature is suitable for this plugin (and double-check if this works properly).

I have not changed `CHANGELOG.md` as I don't know about how to write properly (I am a OSS beginner); please let me not if doing so is a part of collaborator's responsibility.

NB: When I committed for these changes, I used AngularJS styled (ish) commit message, whose subject line exceed little more than 50 characters, which is not recommended by a traditional Git style guide.