### PR TITLE
Added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.vim]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This patch adds .editorconfig file to the project.

This will allow contributors using a text editor or an IDE supporting
editorconfig to have unified settings by default. This patch sets the
following options for all files:

- files are encoded in utf-8
- files are saved with unix end-of-line by default
- trailing whitespaces are trimmed
- the final newline character is inserted

Furthermore, it sets these options for all files ending in .vim:

- use space for identations
- sets the ident level to 4 spaces

For more information about editorconfig see http://editorconfig.org/.