### PR TITLE
Modify headers' update behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Auto add header support
 - Modified date field
 - Modified date by field
+- New algorithm for updating headers allowing them to be updated within a range (g:header_max_size global option)
 
 ### Fixed
 - Make plugin determine file type for each call to catch new file type if changed

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ It sets cfg's filetype comment character as this filetype supports multiple set 
 let g:header_cfg_comment_char = ';'
 ```
 
+This option sets the range from which vim-header will search for required
+headers (ones sets in global options) to determinate if it should update
+existing headers or add new ones.
+```vim
+let g:header_max_size = 20
+```
+This options is used to prevent text replacement if your file contains text
+matching headers (for instance `File:`). Default is 5. See [#20](https://github.com/alpertuna/vim-header/issues/20#issuecomment-319127330) for more explanations.
+
 Support
 -------
 Supported filetypes are;


### PR DESCRIPTION
Closes alpertuna/vim-header#20

This patch modify existing behavior in order to update headers.

The plugin now loops through global options to see which ones are set in
`$MYVIMRC` from which a list is built. Then, it iterates over the list to
see if all headers are present from the start of the file to a certain
threshold (option `g:header_max_size`, **default is 5**).

If one required header is missing, it considers that headers aren't set
so it adds new ones. Otherwise, it updates headers keeping positions and
identations.

Patch also updates the `README.md` and `CHANGELOG.md` to reflect thoses
changes.