### PR TITLE
Prefix header alignment options with header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Modified date field
 - Modified date by field
 - New algorithm for updating headers allowing them to be updated within a range (g:header_max_size global option)
-- Align headers values to longer header name (g:align_headers)
+- Align headers values to longer header name(g:header_alignment)
 
 ### Fixed
 - Make plugin determine file type for each call to catch new file type if changed

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ let g:header_auto_add_header = 0
 ```
 It disables to add header automatically. Default is 1.
 ```vim
-let g:align_headers = 1
+let g:header_alignment = 1
 ```
 It aligns headers' values. Default is 0.
 ```vim
@@ -117,15 +117,7 @@ Supported filetypes are;
 - c
 - cfg
 - clojure
-- cpp
-- cs
-- css
-- elixir
-- erlang
-- go
-- groovy
-- haskel
-- java
+- cpp cs css elixir erlang go groovy haskel java
 - javascript
 - jsx
 - lisp

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -28,8 +28,8 @@ endif
 if !exists('g:header_max_size')
     let g:header_max_size = 7
 endif
-if !exists('g:align_headers')
-    let g:align_headers = 1
+if !exists('g:header_alignment')
+    let g:header_alignment = 1
 endif
 
 " Path for license files directory
@@ -520,7 +520,7 @@ endfun
 fun s:update_fields(longer_header_length)
 
     if match(b:user_headers, b:field_file) != -1
-        if g:align_headers
+        if g:header_alignment
             let b:field_file =
                 \ s:align_field_with_spaces(b:field_file, a:longer_header_length)
         endif
@@ -528,7 +528,7 @@ fun s:update_fields(longer_header_length)
     endif
 
     if match(b:user_headers, b:field_author) != -1
-        if g:align_headers
+        if g:header_alignment
             let b:field_author =
                 \ s:align_field_with_spaces(b:field_author, a:longer_header_length)
         endif
@@ -536,7 +536,7 @@ fun s:update_fields(longer_header_length)
     endif
 
     if match(b:user_headers, b:field_date) != -1
-        if g:align_headers
+        if g:header_alignment
             let b:field_date =
                 \ s:align_field_with_spaces(b:field_date, a:longer_header_length)
         endif
@@ -544,7 +544,7 @@ fun s:update_fields(longer_header_length)
     endif
 
     if match(b:user_headers, b:field_modified_date) != -1
-        if g:align_headers
+        if g:header_alignment
             let b:field_modified_date =
                 \ s:align_field_with_spaces(b:field_modified_date, a:longer_header_length)
         endif
@@ -552,7 +552,7 @@ fun s:update_fields(longer_header_length)
     endif
 
     if match(b:user_headers, b:field_modified_by) != -1
-        if g:align_headers
+        if g:header_alignment
             let b:field_modified_by =
                 \ s:align_field_with_spaces(b:field_modified_by, a:longer_header_length)
         endif


### PR DESCRIPTION
Update #11 

When applied this patch, will modify the option `g:align_headers` to
`g:header_alignment` to preserve consistency with other options.