### PR TITLE
R uses Rscript now

### DIFF
--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -156,7 +156,7 @@ fun s:set_props()
         let b:comment_char = g:header_cfg_comment_char
     " ----------------------------------
     elseif b:filetype == 'r'
-        let b:first_line = '#!/usr/bin/R'
+        let b:first_line = '#!/usr/bin/Rscript'
         let b:first_line_pattern = '#!\s*/usr/bin/r'
         let b:comment_char = '#'
     " ----------------------------------


### PR DESCRIPTION
The bash shell should invoke "Rscript", not "R", to run R programs. My apologies for the mistake.