### PR TITLE
Add VHDL Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Supported filetypes are:
 - scheme
 - sh
 - tmux
+- vhdl
 - vim
 - xdefaults
 - yaml

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -167,6 +167,12 @@ fun s:set_props()
         let b:first_line_pattern = '#!\s*/usr/bin/r'
         let b:comment_char = '#'
     " ----------------------------------
+    elseif b:filetype == 'vhdl'
+        let b:comment_char = '--'
+        " Support for VHDL 2008 block comments
+        let b:comment_begin = '/*'
+        let b:comment_end = '*/'
+    " ----------------------------------
     else
         let b:is_filetype_available = 0
     endif


### PR DESCRIPTION
Added VHDL filetype comment support. Also added block style comments for
VHDL-2008 designs.
Added `vhdl` filetype to list in README.md.

Signed-off-by: John Gentile <johncgentile17@gmail.com>