### PR TITLE
Add Verilog filetype support

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Supported filetypes are:
 - scheme
 - sh
 - tmux
+- verilog
 - vim
 - xdefaults
 - yaml

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -72,7 +72,8 @@ fun s:set_props()
         \ b:filetype == 'php' ||
         \ b:filetype == 'go' ||
         \ b:filetype == 'sass' ||
-        \ b:filetype == 'rust'
+        \ b:filetype == 'rust' ||
+        \ b:filetype == 'verilog'
 
         let b:block_comment = 1
         let b:comment_char = ' *'


### PR DESCRIPTION
Verilog simply uses C-sytle comments so added Verilog filetype to
existing C-style list in `header.vim`