### PR TITLE
Add headers for ReStructuredText

### DIFF
--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -179,9 +179,8 @@ fun s:set_props()
         let b:comment_end = '*/'
         " ----------------------------------
     elseif b:filetype == 'rst'
-        let b:comment_begin = '.. '
-        let b:comment_char = '   '
-        let b:comment_end = '\n'
+        let b:first_line = '..'
+        let b:comment_char = '  '
     " ----------------------------------
     else
         let b:is_filetype_available = 0

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -177,6 +177,11 @@ fun s:set_props()
         " Support for VHDL 2008 block comments
         let b:comment_begin = '/*'
         let b:comment_end = '*/'
+        " ----------------------------------
+    elseif b:filetype == 'rst'
+        let b:comment_begin = '.. '
+        let b:comment_char = '   '
+        let b:comment_end = '\n'
     " ----------------------------------
     else
         let b:is_filetype_available = 0


### PR DESCRIPTION
The comments for `rst` begin with two dots followed by a space `.. `; and continue for all indented text, where the indent in `rst` are 3 consecutive spaces `   `.  A comment must end with a blank line. Thus, an example should look like:

```rst
.. File              : toyfile
   Author            : max mustermann <max@mustermail.com>
   Date              : 03.08.2018
   Last Modified Date: 03.08.2018
   Last Modified By  : max mustermann <max@mustermail.com>

```