### PR TITLE
Fix https://github.com/alpertuna/vim-header/issues/51

### DIFF
--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -311,7 +311,7 @@ fun s:update_header_field_and_value(field, value)
     let field_without_spaces = substitute(a:field, '\s*:$', '', '')
     let field = s:create_pattern_text(field_without_spaces, 1) . '\s*.*'
     let field_add = s:create_pattern_text(a:field) . ' '
-    execute '0,'. g:header_max_size .'s/' . field . '/' . field_add . s:create_pattern_text(a:value) .'/' 
+    execute '0,'. g:header_max_size .'s/' . field . '/' . field_add . s:create_pattern_text(a:value) .'/'
 endfun
 
 " Update header field without changing it's value
@@ -617,6 +617,7 @@ endfun
 fun s:has_required_headers_in_range(header_size_threshold)
     let l:save_pos = getpos(".")
     let l:headers_fields = b:user_headers
+    call setpos(".", [0, 0, 0, 0])
 
     " check if required headers are present and within the range
     for header_field in headers_fields
@@ -627,6 +628,7 @@ fun s:has_required_headers_in_range(header_size_threshold)
             call setpos(".", save_pos)
             return 0
         endif
+        call setpos(".", [0, 0, 0, 0])
     endfor
     call setpos(".", save_pos)
     return 1


### PR DESCRIPTION
## Why the issue occurs:
Because the `search` starts at the cursor position.  Specifically, suppose my cursor is at line 10 now(whatever, as long as that line number is bigger that the `g:header_max_size`).
Now, if there is a header keyword('Author' for example) behind my cursor, `search` will give us a number that is bigger than `a:header_size_threshold`. See following code:
```
" returns 1 if all required headers are present and within the range,
" otherwise returns 0
fun s:has_required_headers_in_range(header_size_threshold)
    let l:save_pos = getpos(".")
    let l:headers_fields = b:user_headers

    " check if required headers are present and within the range
    for header_field in headers_fields
        let header_field_line_nbr = search(header_field)
        if
            \ header_field_line_nbr == 0 ||
            \ header_field_line_nbr > a:header_size_threshold
            call setpos(".", save_pos)
            return 0
        endif
    endfor
    call setpos(".", save_pos)
    return 1
endfun
```
So this function will return `0` and the plugin will consider that there is no headers in the file and automatically add a new header. When we save file again and again, it adds header again and again.

## Solution:
Every time before `search`, I use `call setpos(".", [0, 0, 0, 0])` to move the cursor at the beginning. So the search for header keywords  starts at the beginning always. This method solves the problem successfully as I tested myself.