### PR TITLE
Add support for yacc and lex

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Supported filetypes are:
 - javascript
 - jsx
 - less
+- lex
 - lisp
 - lua
 - matlab/octave
@@ -297,6 +298,7 @@ Supported filetypes are:
 - verilog
 - vim
 - xdefaults
+- yacc
 - yaml
 - vimwiki
 - proto

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -83,7 +83,9 @@ fun s:set_props()
         \ b:filetype == 'go' ||
         \ b:filetype == 'sass' ||
         \ b:filetype == 'rust' ||
-        \ b:filetype == 'verilog'
+        \ b:filetype == 'verilog' ||
+        \ b:filetype == 'lex' ||
+        \ b:filetype == 'yacc'
 
         let b:block_comment = 1
         let b:comment_char = ' *'


### PR DESCRIPTION
Yacc and lex uses C style comments
	modified:   README.md
	modified:   autoload/header.vim