### PR TITLE
update a corrected comment syntax for coldfusion (cfc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,6 @@ Supported filetypes are:
 - arduino
 - asm
 - c
-- cf
-- cfc
-- cfml
 - cfg
 - clojure
 - coldfusion(cfc,cfml)

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -91,9 +91,7 @@ fun s:set_props()
         \ b:filetype == 'systemverilog' ||
         \ b:filetype == 'verilog' ||
         \ b:filetype == 'lex' ||
-        \ b:filetype == 'yacc' ||
-        \ b:filetype == 'cfc' ||
-        \ b:filetype == 'cf'
+        \ b:filetype == 'yacc'
 
         let b:block_comment = 1
         let b:comment_char = ' *'


### PR DESCRIPTION
please merge these new updates, it is working well. I have tested it.

updated the README.MD and /vim-header/autoload/header.vim