### PR TITLE
markdown frontmatter using yaml (instead of codeblocks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Supported filetypes are:
 - lisp
 - lua
 - make
+- markdown
 - matlab/octave
 - ocaml
 - perl

--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -228,8 +228,8 @@ fun s:set_props()
     " ----------------------------------
     elseif b:filetype == 'markdown'
         let b:block_comment = 1
-        let b:comment_begin = '```'
-        let b:comment_end = '```'
+        let b:comment_begin = '---'
+        let b:comment_end = '---'
         " ----------------------------------
     elseif b:filetype == 'tcl'
        let b:first_line = '#!/usr/bin/env tclsh'


### PR DESCRIPTION
This fixes #92 using proposal 1 (see issue).

I simply change the comment string for `markdown` to `---`.

As mentioned in the issue, I could also implement optional support for `yaml` frontmatter.
Just let me know.