### PR TITLE
Add cuda as a file type;

### DIFF
--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -72,6 +72,7 @@ fun s:set_props()
         \ b:filetype == 'arduino' ||
         \ b:filetype == 'c' ||
         \ b:filetype == 'cpp' ||
+        \ b:filetype == 'cuda' ||
         \ b:filetype == 'css' ||
         \ (expand('%:e') == 'cfc' && b:filetype == 'cf') ||
         \ b:filetype == 'groovy' ||


### PR DESCRIPTION
Hi!
First of all, thank you for the plugin. It is enormously helpful.

This is an embarrassingly simple pr to add cuda file type. Due to that CUDA is
generally an extension of C, the header should be the same.

Thank you for considering the addition!