### PR TITLE
Add SHL as available license in code and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Supported filetypes are:
 And licenses are:
 
 - Apache
+- SHL
 - EUP
 - GNU GPL
 - GNU AGPL

--- a/licensefiles/shl
+++ b/licensefiles/shl
@@ -1,0 +1,12 @@
+Licensed under the Solderpad Hardware License v 2.1 (the "License");
+you may not use this file except in compliance with the License, or,
+at your option, the Apache License version 2.0.
+You may obtain a copy of the License at
+
+    https://solderpad.org/licenses/SHL-2.1/
+
+Unless required by applicable law or agreed to in writing, any work
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/plugin/header.vim
+++ b/plugin/header.vim
@@ -5,6 +5,7 @@ command! AddMinHeader call header#add_header(1, 0, 0)
 " License Headers
 command! AddAGPLicense call header#add_header(2, 'agpl', 0)
 command! AddApacheLicense call header#add_header(2, 'apache', 0)
+command! AddSHLLicense call header#add_header(2, 'shl', 0)
 command! AddEUPLicense call header#add_header(2, 'eupl', 0)
 command! AddGNULicense call header#add_header(2, 'gnu', 0)
 command! AddLGPLLicense call header#add_header(2, 'lgpl', 0)


### PR DESCRIPTION
Hi! Thank you for the plugin.

I'm submitting a pull request to add support for the [Solderpad Hardware License](https://solderpad.org) v2.1, which is a hardware-specific wrapper for the Apache License.