### PR TITLE
Added support for custom s/verilog format used in vhda/verilog_system…

### DIFF
--- a/autoload/header.vim
+++ b/autoload/header.vim
@@ -99,6 +99,7 @@ fun s:set_props()
         \ b:filetype == 'rust' ||
         \ b:filetype == 'systemverilog' ||
         \ b:filetype == 'verilog' ||
+        \ b:filetype == 'verilog_systemverilog' ||
         \ b:filetype == 'lex' ||
         \ b:filetype == 'yacc'
 


### PR DESCRIPTION
Hey @alpertuna,

I just added support for one of the most common [plugins](https://github.com/vhda/verilog_systemverilog.vim) in digital circuit engineers use. This plugins updates file extension to `verilog_systemverilog`.
